### PR TITLE
Dockerfile: Sync with latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM nodered/node-red:3.1.9
-
+# Use --build-arg NPM=18 for armv7 & aarch64, check: https://github.com/nodejs/docker-node/issues/1946
+ARG NPM="18"
+FROM nodered/node-red:4.0.3-${NPM}
 USER root
 
 RUN apk update && apk add nginx


### PR DESCRIPTION
Sync with latest node-red[ 4.0 ](https://nodered.org/blog/2024/06/20/version-4-0-released) with improvements.
currently, npm has issues with armv7, which also breaks actual dockerfile build process,
See https://github.com/nodejs/docker-node/issues/1946

As a workaround, use '-build-arg NPM=18' for armv7

Need to test :
- [x] -  node-red-node-serialport built-in module